### PR TITLE
Fix Laravel Pint style issue in phpstan-bootstrap.php

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,2 +1,3 @@
 <?php
+
 ini_set('memory_limit', '512M');


### PR DESCRIPTION
## Summary
- add blank line after opening PHP tag to satisfy Pint style rule

## Testing
- `vendor/bin/pint --test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5fd4c5d0832e9093e456bbe0c90e