### PR TITLE
chore: drop laravel rector set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "pestphp/pest-plugin-laravel": "^2.0",
         "peckphp/peck": "^0.1.3",
         "rector/rector": "^0.19.8",
-        "rector/rector-laravel": "^0.19.0",
         "mockery/mockery": "^1.6",
         "fakerphp/faker": "^1.24"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5a46bf5d6eef11125a9a2dba09d7ab1",
+    "content-hash": "33f1256b87ab86ec85d6e8de8a45846e",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -9577,41 +9577,6 @@
                 }
             ],
             "time": "2024-02-05T10:59:13+00:00"
-        },
-        {
-            "name": "rector/rector-laravel",
-            "version": "0.19.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/driftingly/rector-laravel.git",
-                "reference": "2bbe2cf0e24e2fad43aaaafac64821c633e09d08"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/2bbe2cf0e24e2fad43aaaafac64821c633e09d08",
-                "reference": "2bbe2cf0e24e2fad43aaaafac64821c633e09d08",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "rector-extension",
-            "autoload": {
-                "psr-4": {
-                    "RectorLaravel\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Rector upgrades rules for Laravel Framework",
-            "support": {
-                "issues": "https://github.com/driftingly/rector-laravel/issues",
-                "source": "https://github.com/driftingly/rector-laravel/tree/0.19.0"
-            },
-            "abandoned": "driftingly/rector-laravel",
-            "time": "2023-04-27T04:59:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Set\DeadCodeSetList;
-use Rector\Laravel\Set\LaravelSetList;
-use Rector\TypeDeclaration\Set\TypeDeclarationSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $config): void {
     $config->paths([
@@ -14,9 +12,8 @@ return static function (RectorConfig $config): void {
     ]);
 
     $config->sets([
-        LaravelSetList::LARAVEL_11,
-        TypeDeclarationSetList::TYPE_DECLARATION,
-        DeadCodeSetList::DEAD_CODE,
+        SetList::TYPE_DECLARATION,
+        SetList::DEAD_CODE,
     ]);
 
     $config->parallel();


### PR DESCRIPTION
## Summary
- remove rector-laravel dependency
- simplify Rector config to core sets only

## Testing
- `vendor/bin/pint --test`
- `vendor/bin/pest`
- `vendor/bin/rector --dry-run` *(fails: Call to undefined method PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode::getParamImmediatelyInvokedCallableTagValues)*

------
https://chatgpt.com/codex/tasks/task_e_68bc60acd1b0832e8c0b98002fc002d7