### PR TITLE
Use built-in health check

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,7 +6,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
-        health: '/up',
+        health: '/ping',
     )
     ->withMiddleware()
     ->withExceptions()

--- a/public/index.php
+++ b/public/index.php
@@ -1,19 +1,12 @@
 <?php
 
-use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Configuration\Exceptions;
-use Illuminate\Foundation\Configuration\Middleware;
-
 define('LARAVEL_START', microtime(true));
 
 require __DIR__.'/../vendor/autoload.php';
 
-(new Application)->configure()
-    ->withRouting(web: __DIR__.'/../routes/web.php')
-    ->withMiddleware(function (Middleware $middleware) {
-        //
-    })
-    ->withExceptions(function (Exceptions $exceptions) {
-        //
-    })
-    ->run();
+$app = require __DIR__.'/../bootstrap/app.php';
+
+$app->handleRequest(
+    Illuminate\Http\Request::capture()
+);
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,4 +6,3 @@ use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome');
 
-Route::get('/ping', fn () => 'pong');

--- a/tests/Feature/PingTest.php
+++ b/tests/Feature/PingTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-it('returns pong', function () {
+it('is healthy', function () {
     $response = $this->get('/ping');
 
     $response->assertOk();
-    $response->assertSeeText('pong');
+    $response->assertSeeText('Application up');
 });


### PR DESCRIPTION
## Summary
- configure `/ping` using Laravel's health check route
- simplify application bootstrap and drop custom ping endpoint
- adjust ping feature test for the new health page

## Testing
- `composer test`
- `curl -fsS http://127.0.0.1:8000/ping`


------
https://chatgpt.com/codex/tasks/task_e_68bc68dada94832eae459483808b9ab1