### PR TITLE
Fix test configuration for missing app key and .env warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,34 +4,34 @@ GID ?= $(shell id -g)
 .PHONY: up down restart logs sh php npm migrate seed test e2e
 
 up:
-docker compose up -d --build
+	docker compose up -d --build
 
 down:
-docker compose down
+	docker compose down
 
 restart:
-docker compose restart
+	docker compose restart
 
 logs:
-docker compose logs -f
+	docker compose logs -f
 
 sh:
-docker compose exec app sh
+	docker compose exec app sh
 
 php:
-docker compose exec app php $(ARGS)
+	docker compose exec app php $(ARGS)
 
 npm:
-docker compose exec vite npm $(ARGS)
+	docker compose exec vite npm $(ARGS)
 
 migrate:
-docker compose exec app php artisan migrate
+	docker compose exec app php artisan migrate
 
 seed:
-docker compose exec app php artisan db:seed
+	docker compose exec app php artisan db:seed
 
 test:
-docker compose exec app composer test
+	docker compose exec app composer test
 
 e2e:
-docker compose exec vite npm run test:e2e
+	docker compose exec vite npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@
 ## Getting Started (Docker)
 
 ```bash
-cp .env.docker .env
+cp .env.example .env
+# DB_CONNECTION=pgsql
+# DB_HOST=db
+# DB_PORT=5432
+# DB_DATABASE=app
+# DB_USERNAME=app
+# DB_PASSWORD=app
 make up
+make php ARGS="composer install"
+make npm ARGS="ci"
+make php ARGS="artisan key:generate"
 make migrate
 ```
 
-App: http://localhost:8080  
+App: http://localhost:8080
 HMR: http://localhost:5173
 
 ## Getting Started (Non‑Docker)
@@ -20,7 +29,8 @@ npm ci
 cp .env.example .env   # set DB credentials
 php artisan key:generate
 php artisan migrate
-php artisan serve
+php artisan serve       # http://localhost:8000
+npm run dev            # http://localhost:5173 (separate terminal)
 ```
 
 ## Quality & Tests

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:VaahchN6w9XP73hjiHKUL0hn7JYK8N6rC/3EC812L4o="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,23 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * Create the application instance for testing.
+     */
+    public function createApplication(): Application
+    {
+        $env = dirname(__DIR__).'/.env';
+
+        if (! is_file($env)) {
+            file_put_contents($env, '');
+            register_shutdown_function(static fn () => @unlink($env));
+        }
+
+        return parent::createApplication();
+    }
 }


### PR DESCRIPTION
## Summary
- define APP_KEY in phpunit config for encryption
- bootstrap tests with temporary `.env` file to avoid warnings
- document `npm run dev` step for non-docker setup
- fix Docker setup instructions and Makefile targets

## Testing
- `composer format`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8d151840832eb27290edf0e0f59c