### PR TITLE
feat: add credly certification embeds

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,5 @@
+import '../css/app.css'
 import { createApp } from 'vue'
-import Hello from './components/Hello.vue'
+import Certifications from './components/Certifications.vue'
 
-createApp(Hello).mount('#app')
+createApp(Certifications).mount('#app')

--- a/resources/js/components/Certifications.vue
+++ b/resources/js/components/Certifications.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="min-h-screen bg-gray-50 py-10">
+    <h1 class="mb-8 text-center text-4xl font-bold">My Certifications</h1>
+    <div class="flex flex-wrap justify-center gap-6">
+      <div v-for="id in badgeIds" :key="id">
+        <div
+          :data-share-badge-id="id"
+          data-share-badge-host="https://www.credly.com"
+          data-iframe-width="150"
+          data-iframe-height="270"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+
+const badgeIds = [
+  'ab4c5958-13e5-4af3-9092-2231a1925459',
+]
+
+onMounted(() => {
+  const scriptId = 'credly-embed'
+  if (!document.getElementById(scriptId)) {
+    const script = document.createElement('script')
+    script.id = scriptId
+    script.async = true
+    script.src = 'https://cdn.credly.com/assets/utilities/embed.js'
+    document.body.appendChild(script)
+  }
+})
+</script>

--- a/resources/js/components/Hello.vue
+++ b/resources/js/components/Hello.vue
@@ -1,6 +1,0 @@
-<template>
-    <h1>Hello from Vue!</h1>
-</template>
-
-<script setup>
-</script>


### PR DESCRIPTION
## Summary
- show certifications using Credly embed in Vue component
- mount new certifications component and include Tailwind CSS

## Testing
- `npm test` (fails: Missing script "test")
- `composer test` (fails: pest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc9879be64832e8f7ef58525f83603