### PR TITLE
chore: ignore common tooling terms for peck

### DIFF
--- a/peck.json
+++ b/peck.json
@@ -2,7 +2,23 @@
     "preset": "laravel",
     "ignore": {
         "words": [
-            "php"
+            "php",
+            "dockerfile",
+            "makefile",
+            "filesystems",
+            "eslint",
+            "favicon",
+            "js",
+            "nav",
+            "dropdown",
+            "viewport",
+            "utils",
+            "tooltip",
+            "composables",
+            "ssr",
+            "globals",
+            "wayfinder",
+            "tsconfig"
         ],
         "paths": []
     }


### PR DESCRIPTION
## Summary
- ignore common tooling words like dockerfile, makefile, eslint, and tsconfig for peck

## Testing
- `vendor/bin/peck --ignore-all`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd412a9a0c832e9f7d574bddcbb708