### PR TITLE
Relocate SQLite database and secure access

### DIFF
--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -9,6 +9,10 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    location ~* \.(?:sqlite3?|db)$ {
+        deny all;
+    }
+
     location ~ \.php$ {
         fastcgi_pass app:9000;
         fastcgi_index index.php;

--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,1 +1,2 @@
 *.sqlite*
+!database.sqlite

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,7 @@
+<FilesMatch "\.(db|sqlite)$">
+    Require all denied
+</FilesMatch>
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes


### PR DESCRIPTION
## Summary
- move SQLite database from `public` into dedicated `database` directory
- block direct web access to database files in Apache and Nginx configs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4afd5be0832e923705225fb42599