### PR TITLE
Add Secure flag for appearance cookie on HTTPS

### DIFF
--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -24,7 +24,10 @@ const setCookie = (name: string, value: string, days = 365) => {
 
     const maxAge = days * 24 * 60 * 60;
 
-    document.cookie = `${name}=${value};path=/;max-age=${maxAge};SameSite=Lax`;
+    const secure = typeof window !== 'undefined' && window.location.protocol === 'https:' ? ';Secure' : '';
+
+    // HttpOnly cookies can't be set via JavaScript and must be configured server-side.
+    document.cookie = `${name}=${value};path=/;max-age=${maxAge};SameSite=Lax${secure}`;
 };
 
 const mediaQuery = () => {


### PR DESCRIPTION
## Summary
- Only set the appearance cookie's `Secure` attribute when the page is served over HTTPS
- Document that `HttpOnly` must be configured server-side

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: sh: 1: pest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4b9eb2b0832e9748329f3cadc33d