### PR TITLE
Configure Vite HMR host via env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost:8080
+HMR_HOST=localhost
 
 LOG_CHANNEL=stack
 LOG_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       - node_modules:/var/www/html/node_modules
     ports:
       - "5173:5173"
+    environment:
+      HMR_HOST: ${HMR_HOST:-localhost}
     depends_on:
       - app
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         host: '0.0.0.0',
         port: 5173,
         hmr: {
-            host: 'localhost',
+            host: process.env.HMR_HOST || 'localhost',
             port: 5173,
         },
     },


### PR DESCRIPTION
## Summary
- allow overriding Vite HMR host via `HMR_HOST` env variable
- document `HMR_HOST` in `.env.example`
- pass `HMR_HOST` through docker compose for vite service

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4ba78f64832e8bdf8a54deff6432