### PR TITLE
chore: add wayfinder alias

### DIFF
--- a/resources/js/actions/App/Http/Controllers/Auth/AuthenticatedSessionController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/AuthenticatedSessionController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\AuthenticatedSessionController::create
 * @see app/Http/Controllers/Auth/AuthenticatedSessionController.php:19

--- a/resources/js/actions/App/Http/Controllers/Auth/ConfirmablePasswordController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/ConfirmablePasswordController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\ConfirmablePasswordController::show
 * @see app/Http/Controllers/Auth/ConfirmablePasswordController.php:18

--- a/resources/js/actions/App/Http/Controllers/Auth/EmailVerificationNotificationController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/EmailVerificationNotificationController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\EmailVerificationNotificationController::store
 * @see app/Http/Controllers/Auth/EmailVerificationNotificationController.php:14

--- a/resources/js/actions/App/Http/Controllers/Auth/EmailVerificationPromptController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/EmailVerificationPromptController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\EmailVerificationPromptController::__invoke
 * @see app/Http/Controllers/Auth/EmailVerificationPromptController.php:16

--- a/resources/js/actions/App/Http/Controllers/Auth/NewPasswordController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/NewPasswordController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\NewPasswordController::create
 * @see app/Http/Controllers/Auth/NewPasswordController.php:22

--- a/resources/js/actions/App/Http/Controllers/Auth/PasswordResetLinkController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/PasswordResetLinkController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\PasswordResetLinkController::create
 * @see app/Http/Controllers/Auth/PasswordResetLinkController.php:17

--- a/resources/js/actions/App/Http/Controllers/Auth/RegisteredUserController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/RegisteredUserController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\RegisteredUserController::create
 * @see app/Http/Controllers/Auth/RegisteredUserController.php:21

--- a/resources/js/actions/App/Http/Controllers/Auth/VerifyEmailController.ts
+++ b/resources/js/actions/App/Http/Controllers/Auth/VerifyEmailController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition, applyUrlDefaults } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Auth\VerifyEmailController::__invoke
 * @see app/Http/Controllers/Auth/VerifyEmailController.php:14

--- a/resources/js/actions/App/Http/Controllers/Settings/PasswordController.ts
+++ b/resources/js/actions/App/Http/Controllers/Settings/PasswordController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Settings\PasswordController::edit
 * @see app/Http/Controllers/Settings/PasswordController.php:18

--- a/resources/js/actions/App/Http/Controllers/Settings/ProfileController.ts
+++ b/resources/js/actions/App/Http/Controllers/Settings/ProfileController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \App\Http\Controllers\Settings\ProfileController::edit
 * @see app/Http/Controllers/Settings/ProfileController.php:19

--- a/resources/js/actions/Illuminate/Routing/RedirectController.ts
+++ b/resources/js/actions/Illuminate/Routing/RedirectController.ts
@@ -1,4 +1,4 @@
-import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from './../../../wayfinder'
+import { queryParams, type RouteQueryOptions, type RouteDefinition, type RouteFormDefinition } from '@/wayfinder'
 /**
 * @see \Illuminate\Routing\RedirectController::__invoke
 * @see vendor/laravel/framework/src/Illuminate/Routing/RedirectController.php:19

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,8 @@
         "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         "paths": {
-            /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/*"],
+            "@/*": ["./resources/js/*"],
+            "@/wayfinder": ["./resources/js/wayfinder/index.ts"],
         },
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import laravel from 'laravel-vite-plugin'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
     plugins: [
@@ -10,6 +11,12 @@ export default defineConfig({
         }),
         vue(),
     ],
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+            '@/wayfinder': fileURLToPath(new URL('./resources/js/wayfinder', import.meta.url)),
+        },
+    },
     server: {
         host: '0.0.0.0',
         port: 5173,


### PR DESCRIPTION
## Summary
- add @/wayfinder alias in tsconfig and Vite config
- refactor action imports to use @/wayfinder

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@inertiajs/vue3', and other missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4b74e0e4832e97d81d73ccfc08fc