### PR TITLE
Switch Vite to TypeScript entry point

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,0 @@
-import '../css/app.css'
-import { createApp } from 'vue'
-import Certifications from './components/Certifications.vue'
-
-createApp(Certifications).mount('#app')

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Laravel + Vue</title>
-    @vite('resources/js/app.js')
+    @vite('resources/js/app.ts')
 </head>
 <body>
 <div id="app"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/js/app.js'],
+            input: ['resources/js/app.ts'],
             refresh: true,
         }),
         vue(),


### PR DESCRIPTION
## Summary
- point Vite to `resources/js/app.ts`
- remove obsolete `resources/js/app.js`
- update `welcome.blade.php` to use the new entry point

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4b567570832eb03ae68cf27da664