### PR TITLE
fix: ensure newline at EOF in routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -7,4 +7,3 @@ use Illuminate\Support\Facades\Route;
 Route::view('/', 'welcome');
 Route::get('/ping', fn () => 'pong');
 Route::view('/dashboard', 'welcome')->middleware('auth')->name('dashboard');
-


### PR DESCRIPTION
## Summary
- ensure single newline at EOF in routes/web.php to satisfy Pint

## Testing
- `vendor/bin/pint --test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5c992c84832eb298a46520f6476d