### PR TITLE
docs: add detailed local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,49 @@ App: http://localhost:8080
 HMR: http://localhost:5173
 
 ## Getting Started (Non‑Docker)
+Follow these steps to set up and run the application on your machine without
+Docker.
 
-```bash
-composer install
-npm install && npm run build
-cp .env.example .env   # set DB credentials
-php artisan key:generate
-php artisan migrate
-php artisan serve       # http://localhost:8000
-npm run dev            # http://localhost:5173 (separate terminal)
-```
+1. **Install prerequisites**
+   * PHP 8.3+
+   * [Composer](https://getcomposer.org/)
+   * Node.js 18+ and npm
+   * A running database (PostgreSQL, MySQL, etc.)
+2. **Install PHP dependencies**
+   ```bash
+   composer install
+   ```
+3. **Install JavaScript dependencies**
+   ```bash
+   npm install
+   ```
+4. **Build frontend assets (optional for development)**
+   ```bash
+   npm run build
+   ```
+5. **Copy the example environment file and configure credentials**
+   ```bash
+   cp .env.example .env
+   # edit .env to match your local database settings
+   ```
+6. **Generate the application key**
+   ```bash
+   php artisan key:generate
+   ```
+7. **Run database migrations**
+   ```bash
+   php artisan migrate
+   ```
+8. **Start the backend server**
+   ```bash
+   php artisan serve
+   ```
+   Visit http://localhost:8000
+9. **Start the Vite development server in a separate terminal**
+   ```bash
+   npm run dev
+   ```
+   Hot Module Replacement: http://localhost:5173
 
 ## Quality & Tests
 ```bash


### PR DESCRIPTION
## Summary
- expand non-Docker README section with step-by-step installation guide

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6a00da40832ea277e107ed494d74