### PR TITLE
Fix CertificationResource types for Filament v4

### DIFF
--- a/app/Filament/Resources/CertificationResource.php
+++ b/app/Filament/Resources/CertificationResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\CertificationResource\Pages;
 use App\Helpers\Credly;
 use App\Models\Certification;
+use BackedEnum;
 use Filament\Forms;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Grid;
@@ -12,25 +13,26 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
-use Filament\Resources\Form;
 use Filament\Resources\Resource;
-use Filament\Resources\Table;
+use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use UnitEnum;
 
 class CertificationResource extends Resource
 {
     protected static ?string $model = Certification::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-rectangle-stack';
 
-    protected static ?string $navigationGroup = 'Content';
+    protected static UnitEnum|string|null $navigationGroup = 'Content';
 
-    public static function form(Form $form): Form
+    public static function form(Schema $schema): Schema
     {
-        return $form
+        return $schema
             ->schema([
                 Grid::make(2)
                     ->schema([


### PR DESCRIPTION
## Summary
- update CertificationResource to use BackedEnum and UnitEnum for navigation icon and group
- adjust form and table signatures to use Filament's Schema and Tables APIs

## Testing
- `composer install --no-interaction --prefer-dist --no-progress`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bda719d8e0832ea83db42e0fb80ca0