### PR TITLE
Update Filament resource and model for PHPStan

### DIFF
--- a/app/Filament/Resources/CertificationResource.php
+++ b/app/Filament/Resources/CertificationResource.php
@@ -6,16 +6,18 @@ use App\Filament\Resources\CertificationResource\Pages;
 use App\Helpers\Credly;
 use App\Models\Certification;
 use BackedEnum;
-use Filament\Forms;
+use Filament\Actions;
+use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
-use Filament\Tables;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TernaryFilter;
@@ -54,10 +56,10 @@ class CertificationResource extends Resource
                             ->helperText('Paste your Credly share URL')
                             ->url()
                             ->suffixAction(
-                                Forms\Components\Actions\Action::make('fetchEmbed')
+                                Action::make('fetchEmbed')
                                     ->label('Fetch embed')
                                     ->icon('heroicon-o-arrow-down-tray')
-                                    ->action(function (Forms\Get $get, Forms\Set $set) {
+                                    ->action(function (Get $get, Set $set) {
                                         $url = (string) ($get('credly_url') ?? '');
                                         $iframe = Credly::iframeFromUrl($url);
                                         if (! $iframe) {
@@ -108,13 +110,13 @@ class CertificationResource extends Resource
                 TernaryFilter::make('is_published')->label('Published')->boolean(),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Actions\ViewAction::make(),
+                Actions\EditAction::make(),
+                Actions\DeleteAction::make(),
             ])
             ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
                 ]),
             ])
             ->reorderable('sort_order');

--- a/app/Models/Certification.php
+++ b/app/Models/Certification.php
@@ -3,14 +3,19 @@
 namespace App\Models;
 
 use App\Helpers\Sanitize;
+use Database\Factories\CertificationFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
+/**
+ * @property-read string $embed_html_safe
+ */
 class Certification extends Model
 {
+    /** @use HasFactory<CertificationFactory> */
     use HasFactory, HasUlids;
 
     protected $guarded = [];
@@ -21,6 +26,10 @@ class Certification extends Model
     ];
 
     // Scopes
+    /**
+     * @param  Builder<Certification>  $query
+     * @return Builder<Certification>
+     */
     public function scopePublished(Builder $query): Builder
     {
         return $query->where('is_published', true);

--- a/database/Factories/CertificationFactory.php
+++ b/database/Factories/CertificationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Certification;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Certification>
+ */
+class CertificationFactory extends Factory
+{
+    protected $model = Certification::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(),
+            'issuer' => $this->faker->company(),
+            'issued_at' => $this->faker->date(),
+            'credly_url' => $this->faker->url(),
+            'embed_html' => '<iframe></iframe>',
+            'is_published' => true,
+            'sort_order' => 0,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- adjust Certification resource to Filament v4 namespaces and actions
- add Certification factory and generics
- document embed_html_safe accessor

## Testing
- `vendor/bin/phpstan analyse --no-interaction`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bda8beb620832eb2e760185c387650