### PR TITLE
Gracefully handle missing Vite assets and DB errors on home page

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Certification;
 use Illuminate\View\View;
+use Throwable;
 
 class HomeController extends Controller
 {
@@ -11,12 +12,16 @@ class HomeController extends Controller
     {
         $profile = config('profile');
 
-        $certifications = Certification::query()
-            ->published()
-            ->orderBy('sort_order', 'asc')
-            ->orderByDesc('issued_at')
-            ->limit(6)
-            ->get();
+        try {
+            $certifications = Certification::query()
+                ->published()
+                ->orderBy('sort_order', 'asc')
+                ->orderByDesc('issued_at')
+                ->limit(6)
+                ->get();
+        } catch (Throwable $e) {
+            $certifications = collect();
+        }
 
         return view('home', [
             'profile' => $profile,

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>@yield('title', 'Oleh Mordach — Certifications')</title>
     <meta name="description" content="@yield('meta_description', 'Certifications and profile of Oleh Mordach.')">
-    @if (!app()->environment('testing'))
+    @if (!app()->environment('testing') && file_exists(public_path('build/manifest.json')))
         @vite(['resources/css/app.css', 'resources/js/app.ts'])
     @endif
 </head>


### PR DESCRIPTION
## Summary
- Avoid Vite manifest exception by only loading assets when the manifest is present
- Prevent database connection failures from breaking home page rendering

## Testing
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68bdae8e6278832e956e7e0011e6937a