### PR TITLE
Start test web server for Playwright e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
     testDir: './tests/e2e',
+    webServer: {
+        command: 'node tests/e2e/server.js',
+        port: 8000,
+        reuseExistingServer: !process.env.CI,
+    },
     use: {
         baseURL: 'http://127.0.0.1:8000',
     },

--- a/tests/e2e/server.js
+++ b/tests/e2e/server.js
@@ -1,0 +1,17 @@
+import http from 'http';
+
+const html = `<!DOCTYPE html><html><head><title>Test App</title></head><body><div id="app"></div></body></html>`;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/ping') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('pong');
+  } else {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(html);
+  }
+});
+
+server.listen(8000, '127.0.0.1', () => {
+  console.log('Server running at http://127.0.0.1:8000');
+});


### PR DESCRIPTION
## Summary
- launch a lightweight Node server for Playwright tests
- configure Playwright to start the server before running tests

## Testing
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb5431f08832e8908086952de8567