### PR TITLE
Log homepage query errors to avoid silent failures

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -20,6 +20,10 @@ class HomeController extends Controller
                 ->limit(6)
                 ->get();
         } catch (Throwable $e) {
+            // Log the failure so that issues in production aren't silently ignored
+            report($e);
+
+            // Fall back to an empty collection to keep the homepage rendering
             $certifications = collect();
         }
 

--- a/tests/Feature/HomeControllerLoggingTest.php
+++ b/tests/Feature/HomeControllerLoggingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+it('logs database errors and still renders the homepage', function () {
+    Log::spy();
+
+    // Force a database error when querying certifications
+    Schema::drop('certifications');
+
+    $this->withoutVite();
+    $response = $this->get('/');
+
+    $response->assertOk()
+        ->assertSee('No certifications yet.');
+
+    Log::shouldHaveReceived('error');
+});


### PR DESCRIPTION
## Problem
- Home page swallowed database errors when loading certifications, hiding underlying issues.

## Changes
- Log exceptions in `HomeController` so failures are visible.
- Added feature test ensuring the home page still renders and logs an error when certifications table is missing.

## Risk
- Low: adds logging only when an exception occurs.

## Rollback
- Revert the commit.

## Testing
- `composer test`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc2a4968832e9de004e84224c4fe