### PR TITLE
Harden sanitization and throttle ping route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run build

--- a/app/Helpers/Sanitize.php
+++ b/app/Helpers/Sanitize.php
@@ -21,8 +21,8 @@ class Sanitize
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         libxml_use_internal_errors(true);
-        // Load as HTML fragment
-        $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        // Load as HTML fragment without fetching external entities
+        $dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET);
         libxml_clear_errors();
 
         $allowedAttributes = [

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -20,6 +20,10 @@ class HomeController extends Controller
                 ->limit(6)
                 ->get();
         } catch (Throwable $e) {
+            // Log the failure so that issues in production aren't silently ignored
+            report($e);
+
+            // Fall back to an empty collection to keep the homepage rendering
             $certifications = collect();
         }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\HomeController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [HomeController::class, 'index'])->name('home');
-Route::get('/ping', fn () => 'pong');
+Route::get('/ping', fn () => 'pong')->middleware('throttle:60,1');
 Route::view('/dashboard', 'welcome')->middleware('auth')->name('dashboard');
 
 Route::get('/certifications', [CertificationController::class, 'index'])->name('certifications.index');

--- a/tests/Feature/HomeControllerLoggingTest.php
+++ b/tests/Feature/HomeControllerLoggingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+it('logs database errors and still renders the homepage', function () {
+    Log::spy();
+
+    // Force a database error when querying certifications
+    Schema::drop('certifications');
+
+    $this->withoutVite();
+    $response = $this->get('/');
+
+    $response->assertOk()
+        ->assertSee('No certifications yet.');
+
+    Log::shouldHaveReceived('error');
+});

--- a/tests/Feature/PingRouteTest.php
+++ b/tests/Feature/PingRouteTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+it('throttles ping endpoint after too many requests', function () {
+    for ($i = 0; $i < 60; $i++) {
+        $this->get('/ping')->assertOk();
+    }
+
+    $this->get('/ping')->assertStatus(429);
+});

--- a/tests/Unit/SanitizeIframeTest.php
+++ b/tests/Unit/SanitizeIframeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Helpers\Sanitize;
+
+it('strips external entities when sanitizing iframe html', function () {
+    $html = '<!DOCTYPE foo [<!ENTITY xxe SYSTEM "http://example.com">]><iframe src="https://example.com">&xxe;</iframe>';
+
+    $sanitized = Sanitize::iframe($html);
+
+    expect($sanitized)->toBe('<iframe src="https://example.com" title="Credly badge">&amp;xxe;</iframe>');
+});


### PR DESCRIPTION
## Problem
- Sanitization allowed DOMDocument to load external entities.
- `/ping` health check could be abused without rate limits.
- CI reinstalling npm packages on every run slowed builds.

## Changes
- Added `LIBXML_NONET` to HTML sanitizer to block external entity fetches.
- Applied `throttle:60,1` middleware to `/ping` route.
- Cached npm modules in e2e GitHub Actions job.
- Added tests for sanitization and ping throttling.

## Risk
- Low: touches isolated helper, route, and CI config.

## Rollback
- Revert the commit.

## Testing
- `composer test`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc2a4968832e9de004e84224c4fe